### PR TITLE
make content in create_entry not required

### DIFF
--- a/render_engine_parser/base_parsers.py
+++ b/render_engine_parser/base_parsers.py
@@ -64,15 +64,12 @@ class BasePageParser:
         return content
 
     @staticmethod
-    def create_entry(*, filepath: pathlib.Path | None, content: str = "Hello World", **kwargs) -> str:
+    def create_entry(*, content: str = None, **kwargs) -> str:
         """
         Writes the content type that would be parsed to the content_path.
-
-        attrs:
-          filepath: Only used if reading from an existing path
         """
 
-        post = frontmatter.Post(content)
+        post = frontmatter.Post(content=content or "")
 
         for key, val in kwargs.items():
             post[key] = val

--- a/tests/test_base_parser.py
+++ b/tests/test_base_parser.py
@@ -55,9 +55,15 @@ def test_base_parser_parse_content_path(base_content_path):
     assert expected_result == BasePageParser.parse_content_path(base_content_path)
 
 
+def test_base_parser_empty_entry():
+    """Tests that no content is required"""
+    data = BasePageParser.create_entry()
+    post = frontmatter.loads(data)
+    assert post.content == ""
+
+
 def test_base_parser_net_entry():
     data = BasePageParser.create_entry(
-        filepath=None,  # reminder this is ignored in the base case
         content="This is a Test",
         title="Untitled Entry",
         slug="untitled-entry",


### PR DESCRIPTION
Previously in create entry the default was "Hello World".

This allows the content to be an empty string optionally.

